### PR TITLE
Fixed multiple Cytoscape.js instances issue

### DIFF
--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -1,7 +1,7 @@
 var debounce = require('./debounce');
-var elementUtilities;
 
 module.exports = function (params, cy, api, $) {
+  var elementUtilities;
   var fn = params;
 
   var eMouseOver, eMouseOut, ePosition, eRemove, eTap, eZoom, eAdd, eFree;


### PR DESCRIPTION
This extension was not working as expected with multiple Cytoscape instances (While expanding/collapsing elements on an instance, the elements on the other instance was being affected as well. Extending the user options on an instance was affecting the other one, etc.). This PR is created to solve this problem.