### PR TITLE
Animation duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Notice that following events are performed for *each* node that is collapsed/exp
       // recommended usage: use cose-bilkent layout with randomize: false to preserve mental map upon expand/collapse
       fisheye: true, // whether to perform fisheye view after expand/collapse you can specify a function too
       animate: true, // whether to animate on drawing changes you can specify a function too
+      animationDuration: 1000, // when animate is true, the duration in milliseconds of the animation
       ready: function () { }, // callback when expand/collapse initialized
       undoable: true, // and if undoRedoExtension exists,
 

--- a/cytoscape-expand-collapse.js
+++ b/cytoscape-expand-collapse.js
@@ -953,7 +953,7 @@ return {
                 commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
               }
             }, {
-              duration: 1000
+              duration: animate > 1 ? animate : 1000
             });
           }
           else {
@@ -1175,7 +1175,7 @@ return {
 
           }
         }, {
-          duration: 1000
+          duration: animate > 1 ? animate : 1000
         });
       }
     }

--- a/cytoscape-expand-collapse.js
+++ b/cytoscape-expand-collapse.js
@@ -64,7 +64,7 @@ module.exports = function (params, cy, api, $) {
 
           // refresh the cues on canvas resize
           if(cy){
-            clearDraws(true);
+            clearDraws();
           }
         }, 0);
 
@@ -831,7 +831,7 @@ return {
      * in a batch.
      */ 
     cy.startBatch();
-    this.simpleCollapseGivenNodes(nodes, options);
+    this.simpleCollapseGivenNodes(nodes/*, options*/);
     cy.endBatch();
 
     nodes.trigger("position"); // position not triggered by default when collapseNode is called
@@ -1388,7 +1388,7 @@ module.exports = expandCollapseUtilities;
     
       // set all options at once
       api.setOptions = function(opts) {
-        setScratch(cy, 'options', options);
+        setScratch(cy, 'options', opts);
       };
 
       // set the option whose name is given

--- a/cytoscape-expand-collapse.js
+++ b/cytoscape-expand-collapse.js
@@ -810,7 +810,7 @@ return {
       var node = nodes[0];
       if (node._private.data.collapsedChildren != null) {
         // Expand the given node the third parameter indicates that the node is simple which ensures that fisheye parameter will be considered
-        this.expandNode(node, options.fisheye, true, options.animate, options.layoutBy);
+        this.expandNode(node, options.fisheye, true, options.animate, options.layoutBy, options.animationDuration);
       }
     } 
     else {
@@ -891,10 +891,10 @@ return {
    * applyFishEyeView parameter then the state of view port is to be changed to have extra space on the screen (if needed) before appliying the
    * fisheye view.
    */
-  expandNode: function (node, applyFishEyeView, single, animate, layoutBy) {
+  expandNode: function (node, applyFishEyeView, single, animate, layoutBy, animationDuration) {
     var self = this;
     
-    var commonExpandOperation = function (node, applyFishEyeView, single, animate, layoutBy) {
+    var commonExpandOperation = function (node, applyFishEyeView, single, animate, layoutBy, animationDuration) {
       if (applyFishEyeView) {
 
         node._private.data['width-before-fisheye'] = node._private.data['size-before-collapse'].w;
@@ -903,7 +903,7 @@ return {
         // Fisheye view expand the node.
         // The first paramter indicates the node to apply fisheye view, the third parameter indicates the node
         // to be expanded after fisheye view is applied.
-        self.fishEyeViewExpandGivenNode(node, single, node, animate, layoutBy);
+        self.fishEyeViewExpandGivenNode(node, single, node, animate, layoutBy, animationDuration);
       }
       
       // If one of these parameters is truthy it means that expandNodeBaseFunction is already to be called.
@@ -953,7 +953,7 @@ return {
                 commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
               }
             }, {
-              duration: animate > 1 ? animate : 1000
+              duration: animationDuration || 1000
             });
           }
           else {
@@ -965,7 +965,7 @@ return {
       
       // If animating is not true we need to call commonExpandOperation here
       if (!animating) {
-        commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
+        commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy, animationDuration);
       }
       
       //return the node to undo the operation
@@ -1021,7 +1021,7 @@ return {
    * Apply fisheye view to the given node. nodeToExpand will be expanded after the operation. 
    * The other parameter are to be passed by parameters directly in internal function calls.
    */
-  fishEyeViewExpandGivenNode: function (node, single, nodeToExpand, animate, layoutBy) {
+  fishEyeViewExpandGivenNode: function (node, single, nodeToExpand, animate, layoutBy, animationDuration) {
     var siblings = this.getSiblings(node);
 
     var x_a = this.xPositionInParent(node);
@@ -1112,7 +1112,7 @@ return {
       }
       
       // Move the sibling in the special way
-      this.fishEyeViewMoveNode(sibling, T_x, T_y, nodeToExpand, single, animate, layoutBy);
+      this.fishEyeViewMoveNode(sibling, T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration);
     }
 
     // If there is no sibling call expand node base function here else it is to be called one of fishEyeViewMoveNode() calls
@@ -1122,7 +1122,7 @@ return {
 
     if (node.parent()[0] != null) {
       // Apply fisheye view to the parent node as well ( If exists )
-      this.fishEyeViewExpandGivenNode(node.parent()[0], single, nodeToExpand, animate, layoutBy);
+      this.fishEyeViewExpandGivenNode(node.parent()[0], single, nodeToExpand, animate, layoutBy, animationDuration);
     }
 
     return node;
@@ -1143,7 +1143,7 @@ return {
    * Move node operation specialized for fish eye view expand operation
    * Moves the node by moving its descandents. Movement is animated if both single and animate flags are truthy.
    */
-  fishEyeViewMoveNode: function (node, T_x, T_y, nodeToExpand, single, animate, layoutBy) {
+  fishEyeViewMoveNode: function (node, T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration) {
     var childrenList = cy.collection();
     if(node.isParent()){
        childrenList = node.children(":visible");
@@ -1175,13 +1175,13 @@ return {
 
           }
         }, {
-          duration: animate > 1 ? animate : 1000
+          duration: animationDuration || 1000
         });
       }
     }
     else {
       for (var i = 0; i < childrenList.length; i++) {
-        this.fishEyeViewMoveNode(childrenList[i], T_x, T_y, nodeToExpand, single, animate, layoutBy);
+        this.fishEyeViewMoveNode(childrenList[i], T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration);
       }
     }
   },

--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -133,7 +133,7 @@ return {
       var node = nodes[0];
       if (node._private.data.collapsedChildren != null) {
         // Expand the given node the third parameter indicates that the node is simple which ensures that fisheye parameter will be considered
-        this.expandNode(node, options.fisheye, true, options.animate, options.layoutBy);
+        this.expandNode(node, options.fisheye, true, options.animate, options.animationDuration, options.layoutBy);
       }
     } 
     else {
@@ -214,10 +214,10 @@ return {
    * applyFishEyeView parameter then the state of view port is to be changed to have extra space on the screen (if needed) before appliying the
    * fisheye view.
    */
-  expandNode: function (node, applyFishEyeView, single, animate, layoutBy) {
+  expandNode: function (node, applyFishEyeView, single, animate, layoutBy, animationDuration) {
     var self = this;
     
-    var commonExpandOperation = function (node, applyFishEyeView, single, animate, layoutBy) {
+    var commonExpandOperation = function (node, applyFishEyeView, single, animate, layoutBy, animationDuration) {
       if (applyFishEyeView) {
 
         node._private.data['width-before-fisheye'] = node._private.data['size-before-collapse'].w;
@@ -226,7 +226,7 @@ return {
         // Fisheye view expand the node.
         // The first paramter indicates the node to apply fisheye view, the third parameter indicates the node
         // to be expanded after fisheye view is applied.
-        self.fishEyeViewExpandGivenNode(node, single, node, animate, layoutBy);
+        self.fishEyeViewExpandGivenNode(node, single, node, animate, layoutBy, animationDuration);
       }
       
       // If one of these parameters is truthy it means that expandNodeBaseFunction is already to be called.
@@ -273,10 +273,10 @@ return {
               pan: viewPort.pan,
               zoom: viewPort.zoom,
               complete: function () {
-                commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
+                commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy, animationDuration);
               }
             }, {
-              duration: animate > 1 ? animate : 1000
+              duration: animationDuration || 1000
             });
           }
           else {
@@ -288,7 +288,7 @@ return {
       
       // If animating is not true we need to call commonExpandOperation here
       if (!animating) {
-        commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
+        commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy, animationDuration);
       }
       
       //return the node to undo the operation
@@ -344,7 +344,7 @@ return {
    * Apply fisheye view to the given node. nodeToExpand will be expanded after the operation. 
    * The other parameter are to be passed by parameters directly in internal function calls.
    */
-  fishEyeViewExpandGivenNode: function (node, single, nodeToExpand, animate, layoutBy) {
+  fishEyeViewExpandGivenNode: function (node, single, nodeToExpand, animate, layoutBy, animationDuration) {
     var siblings = this.getSiblings(node);
 
     var x_a = this.xPositionInParent(node);
@@ -435,7 +435,7 @@ return {
       }
       
       // Move the sibling in the special way
-      this.fishEyeViewMoveNode(sibling, T_x, T_y, nodeToExpand, single, animate, layoutBy);
+      this.fishEyeViewMoveNode(sibling, T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration);
     }
 
     // If there is no sibling call expand node base function here else it is to be called one of fishEyeViewMoveNode() calls
@@ -445,7 +445,7 @@ return {
 
     if (node.parent()[0] != null) {
       // Apply fisheye view to the parent node as well ( If exists )
-      this.fishEyeViewExpandGivenNode(node.parent()[0], single, nodeToExpand, animate, layoutBy);
+      this.fishEyeViewExpandGivenNode(node.parent()[0], single, nodeToExpand, animate, layoutBy, animationDuration);
     }
 
     return node;
@@ -466,7 +466,7 @@ return {
    * Move node operation specialized for fish eye view expand operation
    * Moves the node by moving its descandents. Movement is animated if both single and animate flags are truthy.
    */
-  fishEyeViewMoveNode: function (node, T_x, T_y, nodeToExpand, single, animate, layoutBy) {
+  fishEyeViewMoveNode: function (node, T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration) {
     var childrenList = cy.collection();
     if(node.isParent()){
        childrenList = node.children(":visible");
@@ -498,13 +498,13 @@ return {
 
           }
         }, {
-          duration: animate > 1 ? animate : 1000
+          duration: animationDuration || 1000
         });
       }
     }
     else {
       for (var i = 0; i < childrenList.length; i++) {
-        this.fishEyeViewMoveNode(childrenList[i], T_x, T_y, nodeToExpand, single, animate, layoutBy);
+        this.fishEyeViewMoveNode(childrenList[i], T_x, T_y, nodeToExpand, single, animate, layoutBy, animationDuration);
       }
     }
   },

--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -154,7 +154,7 @@ return {
      * in a batch.
      */ 
     cy.startBatch();
-    this.simpleCollapseGivenNodes(nodes, options);
+    this.simpleCollapseGivenNodes(nodes/*, options*/);
     cy.endBatch();
 
     nodes.trigger("position"); // position not triggered by default when collapseNode is called

--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -276,7 +276,7 @@ return {
                 commonExpandOperation(node, applyFishEyeView, single, animate, layoutBy);
               }
             }, {
-              duration: 1000
+              duration: animate > 1 ? animate : 1000
             });
           }
           else {
@@ -498,7 +498,7 @@ return {
 
           }
         }, {
-          duration: 1000
+          duration: animate > 1 ? animate : 1000
         });
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@
     
       // set all options at once
       api.setOptions = function(opts) {
-        setScratch(cy, 'options', options);
+        setScratch(cy, 'options', opts);
       };
 
       // set the option whose name is given


### PR DESCRIPTION
Overloads the `animate` property. If passed a value greater than 1/true it represents the number of milliseconds to use as the animation duration.

Also fixed a typo in the api options