### PR TITLE
fixed findNewEnd method

### DIFF
--- a/src/expandCollapseUtilities.js
+++ b/src/expandCollapseUtilities.js
@@ -602,8 +602,8 @@ return {
   },
   findNewEnd: function(node) {
     var current = node;
-    
-    while( !current.inside() ) {
+
+    while(current.data("parent") === node.data("id")) {
       current = current.parent();
     }
     


### PR DESCRIPTION
Hi,
findNewEnd method is stuck in infinite loop, when I have edge connecting nodes from different compound nodes. 
My idea is, if the node is inside compound then node.data("parent") is equal to compound.data("id"). In this case we have to go up in the nodes hierarchy to find the compound node itself, so we can connect it with the edge when expanding/collapsing  