### PR TITLE
Cy expand collapse expanded node class addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Notice that following events are performed for *each* node that is collapsed/exp
 ## Elements Style
 
  * Collapsed nodes have 'cy-expand-collapse-collapsed-node' class.
+ * Expanded nodes have 'cy-expand-collapse-expanded-node' class.
  * Meta edges have 'cy-expand-collapse-meta-edge' class.
 
 ## Dependencies

--- a/cytoscape-expand-collapse.js
+++ b/cytoscape-expand-collapse.js
@@ -753,6 +753,7 @@ return {
 
     node.removeData("infoLabel");
     node.removeClass('cy-expand-collapse-collapsed-node');
+    node.addClass('cy-expand-collapse-expanded-node');
 
     node.trigger("expandcollapse.beforeexpand");
     var restoredNodes = node._private.data.collapsedChildren;
@@ -1052,6 +1053,7 @@ return {
       
       this.barrowEdgesOfcollapsedChildren(node);
       this.removeChildren(node, node);
+      node.removeClass('cy-expand-collapse-expanded-node');
       node.addClass('cy-expand-collapse-collapsed-node');
 
       node.trigger("expandcollapse.aftercollapse");


### PR DESCRIPTION
I added the class 'cy-expand-collapse-expanded-node' for expanded nodes. I realized there was a class for collapsed nodes, but I needed it for expanded ones too.