### PR TITLE
Fixes cue delay for animation

### DIFF
--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -284,7 +284,7 @@ module.exports = function (params, cy, api) {
       cy.on('pan zoom', data.ePosition);
 
       cy.on('expandcollapse.afterexpand expandcollapse.aftercollapse', 'node', data.eAfterExpandCollapse = function () {
-        var delay = 50 + params.animate ? params.animationDuration : 0;
+        var delay = 50 + (params.animate ? params.animationDuration : 0);
         setTimeout(() => {
           if (this.selected()) {
             drawExpandCollapseCue(this);


### PR DESCRIPTION
50 + params.animate ? params.animationDuration : 0; evaluates to either 0 or param.animationDuration.
50 + (params.animate ? params.animationDuration : 0); was probably what was intended