### PR TITLE
Makes it compatible with EdgeHandles extension

### DIFF
--- a/src/cueUtilities.js
+++ b/src/cueUtilities.js
@@ -208,8 +208,11 @@ module.exports = function (params, cy, api) {
         currMousePos = e.renderedPosition || e.cyRenderedPosition
       });
 
-      cy.on('remove', 'node', data.eRemove = function () {
-        clearDraws();
+      cy.on('remove', 'node', data.eRemove = function (evt) {
+        const node = evt.target;
+        if (node == nodeWithRenderedCue){
+          clearDraws();
+        }      
       });
 
       var ur;


### PR DESCRIPTION
Edgehandles extension removes the handle node on click, which disables the cue and makes it unclickable.  By checking that the removed node is the node with the cue, we make both extensions compatible.